### PR TITLE
Add config option to support paths relative to the current file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.0
+* Add configuration option to support paths relative to the current file ([#13](https://github.com/Zettelkasten-Method/atom-wikilink/issues/13)) -- [@theshoals](https://github.com/theshoals)
+* Avoid TypeError when there's no active editor pane ([#10](https://github.com/Zettelkasten-Method/atom-wikilink/issues/10)) -- [@theshoals](https://github.com/theshoals)
+* Avoid TypeError when following a link in an unsaved file ([#12](https://github.com/Zettelkasten-Method/atom-wikilink/issues/12)) -- [@theshoals](https://github.com/theshoals)
+
 ## 0.15.0
 * Avoid TypeError when attempting to copy link to unsaved file ([#9](https://github.com/Zettelkasten-Method/atom-wikilink/pull/9)) -- [@theshoals](https://github.com/theshoals)
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs-plus'
 glob = require 'glob'
+path = require 'path'
 escapeStringRegexp = require 'escape-string-regexp'
 
 module.exports =
@@ -11,17 +12,30 @@ class LinkProvider
     prefix = @getPrefix(editor, bufferPosition)
     return unless prefix[0] is atom.config.get('wikilink.linkbegin')[0]
     new Promise (resolve) ->
-      [projPath, relPath] = atom.project.relativizePath(editor?.buffer?.file?.path)
-      noteDirectory = fs.normalize(projPath)
+      suggestions = []
+
+      filePath = editor?.buffer?.file?.path
+      if not filePath
+        resolve(suggestions)
+
+      linkResolution = atom.config.get('wikilink.linkresolution')
+
+      if linkResolution is 'project'
+        [projPath, relPath] = atom.project.relativizePath(filePath)
+        if not projPath
+          resolve(suggestions)
+
+        noteDirectory = fs.normalize(projPath)
+      else if linkResolution is 'file'
+        noteDirectory = path.dirname(filePath)
+
       noteExtension = atom.config.get('wikilink.extension')
       noteGlob = "**/*" + noteExtension
       notes = glob.sync(noteGlob, {cwd: noteDirectory})
 
-      suggestions = []
       for note in notes
         note = note.replace noteExtension, ""
         suggestions.push
-          selector: '.source.gfm'
           text: note
 
       resolve(suggestions)

--- a/lib/wikilink.coffee
+++ b/lib/wikilink.coffee
@@ -27,6 +27,15 @@ module.exports = atomWikiLink =
       description: 'The regex used to identify the contents of a link'
       type: 'string'
       default: '(.+)'
+    linkresolution:
+      title: 'Link Resolution'
+      description: 'The method used to resolve links'
+      type: 'string'
+      default: 'project'
+      enum: [
+        {value: 'project', description: 'Links are resolved relative to the root project folders'}
+        {value: 'file', description: 'Links are resolved relative to the current file'}
+      ]
   subscriptions: null
 
   activate: (state) ->
@@ -56,8 +65,27 @@ module.exports = atomWikiLink =
 
   follow: ->
     editor = atom.workspace.getActiveTextEditor()
-    [projPath, relPath] = atom.project.relativizePath(editor?.buffer?.file?.path)
-    noteDirectory = fs.normalize(projPath)
+    if not editor
+      console.log('An editor window must be active before you can follow a link.')
+      return
+
+    filePath = editor.buffer?.file?.path
+    if not filePath
+      console.log('You must save the file before you can follow a link.')
+      return
+
+    linkResolution = atom.config.get('wikilink.linkresolution')
+
+    if linkResolution is 'project'
+      [projPath, relPath] = atom.project.relativizePath(filePath)
+      if not projPath
+        console.log('The file is not saved in a project folder.')
+        return
+
+      noteDirectory = fs.normalize(projPath)
+    else if linkResolution is 'file'
+      noteDirectory = path.dirname(filePath)
+
     noteExtension = atom.config.get('wikilink.extension')
     cursorPosition = editor.getCursorBufferPosition()
     buffer = editor.getBuffer()
@@ -82,18 +110,32 @@ module.exports = atomWikiLink =
         match = pattern.exec currentRow
 
   copyLink: ->
+    editor = atom.workspace.getActiveTextEditor()
+    if not editor
+      console.log('An editor window must be active before you can copy a link.')
+      return
+
+    filePath = editor.buffer?.file?.path
+    if not filePath
+      console.log('You must save the file before you can copy a link to it.')
+      return
+
     noteExtension = atom.config.get('wikilink.extension')
     linkBegin = atom.config.get('wikilink.linkbegin')
     linkEnd = atom.config.get('wikilink.linkend')
-    editor = atom.workspace.getActiveTextEditor()
-    [projPath, relPath] = atom.project.relativizePath(editor?.buffer?.file?.path)
-    if relPath
-        text = relPath.replace noteExtension, ""
-        text = text.replace /^\/+|^\\+/g, ""
-        text = linkBegin + text + linkEnd
-        atom.clipboard.write(text)
-    else
-        console.log('You must save the file before you can copy a link to it.')
+    linkResolution = atom.config.get('wikilink.linkresolution')
+
+    if linkResolution is 'project'
+      [projPath, relPath] = atom.project.relativizePath(filePath)
+      if not relPath
+        console.log('The file must be saved in a project folder before you can copy a link to it.')
+        return
+    else if linkResolution is 'file'
+      relPath = path.basename(filePath)
+
+    text = relPath.replace noteExtension, ""
+    text = linkBegin + text + linkEnd
+    atom.clipboard.write(text)
 
   provide: ->
     unless @provider?


### PR DESCRIPTION
This commit also contains the following patches:

Avoid TypeError when there's no active editor pane (#10)
Avoid TypeError when following a link in an unsaved file (#12)

Closes #8
Closes #10
Closes #12
Closes #13