### PR TITLE
Use a non-greedy regex to match links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.17.0
+* Use a non-greedy regex to match links ([#15](https://github.com/Zettelkasten-Method/atom-wikilink/issues/15)) -- [@theshoals](https://github.com/theshoals)
+
 ## 0.16.0
 * Add configuration option to support paths relative to the current file ([#13](https://github.com/Zettelkasten-Method/atom-wikilink/issues/13)) -- [@theshoals](https://github.com/theshoals)
 * Avoid TypeError when there's no active editor pane ([#10](https://github.com/Zettelkasten-Method/atom-wikilink/issues/10)) -- [@theshoals](https://github.com/theshoals)

--- a/lib/wikilink.coffee
+++ b/lib/wikilink.coffee
@@ -26,7 +26,7 @@ module.exports = atomWikiLink =
       title: 'Link Regex'
       description: 'The regex used to identify the contents of a link'
       type: 'string'
-      default: '(.+)'
+      default: '(.+?[\\]]?)'
     linkresolution:
       title: 'Link Resolution'
       description: 'The method used to resolve links'


### PR DESCRIPTION
This allows multiple links to work on the same line.

Closes #15