### PR TITLE
Constrain the escape-string-regexp dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.17.0
 * Use a non-greedy regex to match links ([#15](https://github.com/Zettelkasten-Method/atom-wikilink/issues/15)) -- [@theshoals](https://github.com/theshoals)
+* Constrain the escape-string-regexp dependency ([#17](https://github.com/Zettelkasten-Method/atom-wikilink/issues/17)) -- [@theshoals](https://github.com/theshoals)
 
 ## 0.16.0
 * Add configuration option to support paths relative to the current file ([#13](https://github.com/Zettelkasten-Method/atom-wikilink/issues/13)) -- [@theshoals](https://github.com/theshoals)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "escape-string-regexp": ">=1.0.5",
+    "escape-string-regexp": ">=1.0.5 <5.0.0",
     "fs-plus": "2.x",
     "glob": ">=7.1.1"
   },


### PR DESCRIPTION
v5.0.0 uses ECMAScript modules, which do not seem supported.

Closes #17